### PR TITLE
make mapzen search host an option

### DIFF
--- a/R/mz-search-main.R
+++ b/R/mz-search-main.R
@@ -11,7 +11,7 @@ search_url <- function(endpoint, ..., api_key = mz_key()) {
     structure(
         list(
             scheme = "https",
-            hostname = "search.mapzen.com",
+            hostname = getOption("RMAPZEN.search.host"),
             path = search_path(endpoint),
             query = query),
         class = "url"

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,3 @@
+.onAttach <- function(libname, pkgname) {
+    options(RMAPZEN.search.host="search.mapzen.com")
+}


### PR DESCRIPTION
Since mapzen is shutting, this change makes the search host an option instead of hard coding it in `search_url`. That way, one can change the host via 

    options(RMAPZEN.search.host = "api.geocode.earth")

One then needs a different MAPZEN_KEY of course. 