### PR TITLE
Some improvements to host option

### DIFF
--- a/R/matrix-main.R
+++ b/R/matrix-main.R
@@ -6,7 +6,7 @@ matrix_url <- function(endpoint, ..., api_key = mz_key()) {
     structure(
         list(
             scheme = "https",
-            hostname = "matrix.mapzen.com",
+            hostname = getOption("RMAPZEN.matrix.host"),
             path = matrix_path(endpoint),
             query = query),
         class = "url"

--- a/R/matrix-main.R
+++ b/R/matrix-main.R
@@ -6,7 +6,7 @@ matrix_url <- function(endpoint, ..., api_key = mz_key()) {
     structure(
         list(
             scheme = "https",
-            hostname = getOption("RMAPZEN.matrix.host"),
+            hostname = getOption("RMAPZEN_MATRIX_HOST"),
             path = matrix_path(endpoint),
             query = query),
         class = "url"

--- a/R/mz-search-main.R
+++ b/R/mz-search-main.R
@@ -11,7 +11,7 @@ search_url <- function(endpoint, ..., api_key = mz_key()) {
     structure(
         list(
             scheme = "https",
-            hostname = getOption("RMAPZEN.search.host"),
+            hostname = getOption("RMAPZEN_SEARCH_HOST"),
             path = search_path(endpoint),
             query = query),
         class = "url"

--- a/R/vector-tiles.R
+++ b/R/vector-tiles.R
@@ -133,7 +133,7 @@ vector_url <- function(x, y, z, layers = "all", format = "json", api_key = mz_ke
     structure(
         list(
             scheme = "https",
-            hostname = getOption("RMAPZEN.tile.host"),
+            hostname = getOption("RMAPZEN_TILE_HOST"),
             path = vector_path(layers, x, y, z, format),
             query = list(
                 api_key = api_key

--- a/R/vector-tiles.R
+++ b/R/vector-tiles.R
@@ -133,7 +133,7 @@ vector_url <- function(x, y, z, layers = "all", format = "json", api_key = mz_ke
     structure(
         list(
             scheme = "https",
-            hostname = "tile.mapzen.com",
+            hostname = getOption("RMAPZEN.tile.host"),
             path = vector_path(layers, x, y, z, format),
             query = list(
                 api_key = api_key

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,10 @@
 .onLoad <- function(libname, pkgname) {
-    options(RMAPZEN.search.host="search.mapzen.com")
+    rmapzen_default_options <- list(
+        RMAPZEN.search.host = "search.mapzen.com"
+    )
+    op <- options()
+    toset <- !(names(rmapzen_default_options) %in% names(op))
+    if(any(toset)) options(rmapzen_default_options[toset])
+
+    invisible()
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,6 +1,8 @@
 .onLoad <- function(libname, pkgname) {
     rmapzen_default_options <- list(
-        RMAPZEN.search.host = "search.mapzen.com"
+        RMAPZEN.matrix.host = "matrix.mapzen.com",
+        RMAPZEN.search.host = "search.mapzen.com",
+        RMAPZEN.tile.host   = "tile.mapzen.com"
     )
     op <- options()
     toset <- !(names(rmapzen_default_options) %in% names(op))

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,3 @@
-.onAttach <- function(libname, pkgname) {
+.onLoad <- function(libname, pkgname) {
     options(RMAPZEN.search.host="search.mapzen.com")
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,8 +1,8 @@
 .onLoad <- function(libname, pkgname) {
     rmapzen_default_options <- list(
-        RMAPZEN.matrix.host = "matrix.mapzen.com",
-        RMAPZEN.search.host = "search.mapzen.com",
-        RMAPZEN.tile.host   = "tile.mapzen.com"
+        RMAPZEN_MATRIX_HOST = "matrix.mapzen.com",
+        RMAPZEN_SEARCH_HOST = "search.mapzen.com",
+        RMAPZEN_TILE_HOST   = "tile.mapzen.com"
     )
     op <- options()
     toset <- !(names(rmapzen_default_options) %in% names(op))
@@ -10,3 +10,4 @@
 
     invisible()
 }
+


### PR DESCRIPTION
I improved my first attempt a bit. This now...

1. uses `.onLoad` instead of `.onAttach`. Otherwise e.g. `rmapzen::mz_search()` wouldn't work (I think) without attaching ´rmapzen` (i.e. call `library(rmapzen)`) first. 
2. only sets options if they are not already available, i.e. it does not override existing options. That way one can set `options()` before loading `rmapzen`. -> one can set the `rmapzen` host more permanently in `.Rprofile` for example - in case one regularly uses the same host. 
3. adds `RMAPZEN.matrix.host` and `RMAPZEN.tile.host`.

I am not sure whether it is safe to assume that the `endpoint`/`vector_path` is alway the same over different hosts (e.g. local Pelias installs) and so whether there should also be options for that (or just one combined `host/endpoint` optoin). But perhaps let's just see first how this pans out. 